### PR TITLE
Fix last bracket for cpp

### DIFF
--- a/gblink.h
+++ b/gblink.h
@@ -80,7 +80,7 @@ void *gblink_alloc(struct gblink_def *gblink_def);
 void gblink_free(void *handle);
 
 #ifdef __cplusplus
-{
+}
 #endif
 
 #endif // __GBLINK_H__


### PR DESCRIPTION
I changed the last bracket in CPP as it wasn't closing properly.

https://github.com/kbembedded/flipper-gblink/blob/421f945c112954a175465f5a0a1e5f61f7319780/gblink.h#L82-L84